### PR TITLE
Install react-test-renderer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12745,6 +12745,37 @@
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.4.3.tgz",
       "integrity": "sha512-Hwln1VNuGl/6bVwnd0Xdn1e84gT/8T9aYNL+HAKDArLCS7LWjwr7StE30IEYbIkx0Vi3vs+coQxe+SQDbGbbpA=="
     },
+    "react-shallow-renderer": {
+      "version": "16.14.1",
+      "resolved": "https://registry.npmjs.org/react-shallow-renderer/-/react-shallow-renderer-16.14.1.tgz",
+      "integrity": "sha512-rkIMcQi01/+kxiTE9D3fdS959U1g7gs+/rborw++42m1O9FAQiNI/UNRZExVUoAOprn4umcXf+pFRou8i4zuBg==",
+      "requires": {
+        "object-assign": "^4.1.1",
+        "react-is": "^16.12.0 || ^17.0.0"
+      }
+    },
+    "react-test-renderer": {
+      "version": "17.0.1",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-17.0.1.tgz",
+      "integrity": "sha512-/dRae3mj6aObwkjCcxZPlxDFh73XZLgvwhhyON2haZGUEhiaY5EjfAdw+d/rQmlcFwdTpMXCSGVk374QbCTlrA==",
+      "requires": {
+        "object-assign": "^4.1.1",
+        "react-is": "^17.0.1",
+        "react-shallow-renderer": "^16.13.1",
+        "scheduler": "^0.20.1"
+      },
+      "dependencies": {
+        "scheduler": {
+          "version": "0.20.1",
+          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.1.tgz",
+          "integrity": "sha512-LKTe+2xNJBNxu/QhHvDR14wUXHRQbVY5ZOYpOGWRzhydZUqrLb2JBvLPY7cAqFmqrWuDED0Mjk7013SZiOz6Bw==",
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1"
+          }
+        }
+      }
+    },
     "react-timer-mixin": {
       "version": "0.13.4",
       "resolved": "https://registry.npmjs.org/react-timer-mixin/-/react-timer-mixin-0.13.4.tgz",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "react-native": "https://github.com/expo/react-native/archive/sdk-40.0.1.tar.gz",
     "react-native-elements": "^3.1.0",
     "react-native-vector-icons": "^8.0.0",
-    "react-native-web": "~0.13.12"
+    "react-native-web": "~0.13.12",
+    "react-test-renderer": "^17.0.1"
   },
   "devDependencies": {
     "@babel/core": "~7.9.0"


### PR DESCRIPTION
We need `react-test-renderer` to run snapshot tests in Jest.