### PR TITLE
Install eslint-config-prettier

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5601,6 +5601,11 @@
         "object.entries": "^1.1.2"
       }
     },
+    "eslint-config-prettier": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-7.2.0.tgz",
+      "integrity": "sha512-rV4Qu0C3nfJKPOAhFujFxB7RMP+URFyQqqOZW9DMRD7ZDTFyjaIlETU3xzHELt++4ugC0+Jm084HQYkkJe+Ivg=="
+    },
     "eslint-plugin-jest": {
       "version": "24.1.3",
       "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-24.1.3.tgz",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "eslint": "^7.18.0",
     "eslint-config-airbnb": "^18.2.1",
+    "eslint-config-prettier": "^7.2.0",
     "eslint-plugin-jest": "^24.1.3",
     "eslint-plugin-prettier": "^3.3.1",
     "expo": "~40.0.0",


### PR DESCRIPTION
`eslint-config-prettier` is a requirement for running `eslint` with `prettier`.