### PR TITLE
Fix pipeline linter fail due to the existing `master` branch, cache `node_modules` in every job

### DIFF
--- a/.github/workflows/branch-build.yml
+++ b/.github/workflows/branch-build.yml
@@ -15,7 +15,7 @@ jobs:
           fetch-depth: 0
       # Merge with master
       - name: Merge with master
-        run: ORIG_BRANCH=$(git rev-parse --abbrev-ref HEAD); if [ $ORIG_BRANCH != "master" ]; then git checkout -b master; fi; git pull origin master && git merge $ORIG_BRANCH
+        run: ORIG_BRANCH=$(git rev-parse --abbrev-ref HEAD); (git checkout master || git checkout -b master) && git pull origin master && git merge $ORIG_BRANCH
       # Cache node_modules and refresh the cache only when package-lock.son changes
       - name: Cache node_modules
         uses: actions/cache@v2
@@ -44,7 +44,7 @@ jobs:
           fetch-depth: 0
       # Merge with master
       - name: Merge with master
-        run: ORIG_BRANCH=$(git rev-parse --abbrev-ref HEAD); if [ $ORIG_BRANCH != "master" ]; then git checkout -b master; fi; git pull origin master && git merge $ORIG_BRANCH
+        run: ORIG_BRANCH=$(git rev-parse --abbrev-ref HEAD); (git checkout master || git checkout -b master) && git pull origin master && git merge $ORIG_BRANCH
       # Install dependencies
       - name: Install dependencies
         run: npm install
@@ -63,7 +63,7 @@ jobs:
           fetch-depth: 0
       # Merge with master
       - name: Merge with master
-        run: ORIG_BRANCH=$(git rev-parse --abbrev-ref HEAD); if [ $ORIG_BRANCH != "master" ]; then git checkout -b master; fi; git pull origin master && git merge $ORIG_BRANCH
+        run: ORIG_BRANCH=$(git rev-parse --abbrev-ref HEAD); (git checkout master || git checkout -b master) && git pull origin master && git merge $ORIG_BRANCH
       # Install dependencies
       - name: Install dependencies
         run: npm install

--- a/.github/workflows/branch-build.yml
+++ b/.github/workflows/branch-build.yml
@@ -48,6 +48,19 @@ jobs:
       # Install dependencies
       - name: Install dependencies
         run: npm install
+      # Cache node_modules and refresh the cache only when package-lock.son changes
+      - name: Cache node_modules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-node-modules
+        with:
+          # npm cache files are stored in `~/.npm` on Linux/macOS
+          path: ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
       # Runs ESLint
       - name: Run ESLint
         run: npm run lint .
@@ -67,6 +80,19 @@ jobs:
       # Install dependencies
       - name: Install dependencies
         run: npm install
+      # Cache node_modules and refresh the cache only when package-lock.son changes
+      - name: Cache node_modules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-node-modules
+        with:
+          # npm cache files are stored in `~/.npm` on Linux/macOS
+          path: ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
       # Runs unit tests
       - name: Run unit tests
         run: npm run test

--- a/.github/workflows/branch-build.yml
+++ b/.github/workflows/branch-build.yml
@@ -15,7 +15,7 @@ jobs:
           fetch-depth: 0
       # Merge with master
       - name: Merge with master
-        run: ORIG_BRANCH=$(git rev-parse --abbrev-ref HEAD); git checkout -b master && git pull origin master && git merge $ORIG_BRANCH
+        run: ORIG_BRANCH=$(git rev-parse --abbrev-ref HEAD); if [ $ORIG_BRANCH != "master" ]; then git checkout -b master; fi; git pull origin master && git merge $ORIG_BRANCH
       # Cache node_modules and refresh the cache only when package-lock.son changes
       - name: Cache node_modules
         uses: actions/cache@v2
@@ -44,7 +44,7 @@ jobs:
           fetch-depth: 0
       # Merge with master
       - name: Merge with master
-        run: ORIG_BRANCH=$(git rev-parse --abbrev-ref HEAD); git checkout -b master && git pull origin master && git merge $ORIG_BRANCH
+        run: ORIG_BRANCH=$(git rev-parse --abbrev-ref HEAD); if [ $ORIG_BRANCH != "master" ]; then git checkout -b master; fi; git pull origin master && git merge $ORIG_BRANCH
       # Install dependencies
       - name: Install dependencies
         run: npm install
@@ -63,7 +63,7 @@ jobs:
           fetch-depth: 0
       # Merge with master
       - name: Merge with master
-        run: ORIG_BRANCH=$(git rev-parse --abbrev-ref HEAD); git checkout -b master && git pull origin master && git merge $ORIG_BRANCH
+        run: ORIG_BRANCH=$(git rev-parse --abbrev-ref HEAD); if [ $ORIG_BRANCH != "master" ]; then git checkout -b master; fi; git pull origin master && git merge $ORIG_BRANCH
       # Install dependencies
       - name: Install dependencies
         run: npm install


### PR DESCRIPTION
The previous pipeline linter did not work for the `master` branch, as `git checkout -b master` throws an error when `master` already exists. This PR introduces a fix for that error using the OR operation.

Caching of `node_modules` was introduced to every job as well, as the cache in the root job does not carry over. The dynamic generation of this config YML file will be necessary as the number of jobs increase.